### PR TITLE
Refactor/chromadb rbac filtering with support for Manager, staff, departments, and customers

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,10 @@
 import streamlit as st
-import time  # For simulating typing effect
+import time # For simulating typing effect
 
 # Import functions from other modules
-from config import ROLES, TICKET_TEAMS
-from rag_processor import get_rag_chain, vector_store  # Import vector_store to check if initialized
+from config import ROLES, TICKET_TEAMS, LLM_MODEL
+# Import vector_store check and get_rag_chain
+from rag_processor import get_rag_chain, vector_store
 from ticket_system import suggest_ticket_team, create_ticket
 from feedback_system import record_feedback
 
@@ -12,79 +13,106 @@ st.set_page_config(page_title="Internal Knowledge Assistant PoC", layout="wide")
 st.title("🤖 Internal Knowledge Assistant PoC")
 st.caption("Ask questions about company policies, projects, and procedures.")
 
-# --- Initialize Database ---
-# (Done implicitly by importing database_utils in other modules)
 
 # --- Mock Login & Role Selection ---
+# Initialize session state variables if they don't exist
+default_role = ROLES[0] # Default to the first role in the list, e.g., 'staff'
 if 'user_role' not in st.session_state:
-    st.session_state.user_role = None
+    st.session_state.user_role = None # Start with no role selected initially
 if 'rag_chain' not in st.session_state:
-    st.session_state.rag_chain = None
+     st.session_state.rag_chain = None
 if 'show_ticket_form' not in st.session_state:
     st.session_state.show_ticket_form = False
 if 'last_question' not in st.session_state:
     st.session_state.last_question = ""
 if 'chat_history' not in st.session_state:
-    st.session_state.chat_history = []  # Store {'role': 'user'/'assistant', 'content': ...}
+    st.session_state.chat_history = [] # Store {'role': 'user'/'assistant', 'content': ...}
 
 # Sidebar for role selection
 with st.sidebar:
     st.header("User Role")
+    # Use index=None for initial state if user_role is None, otherwise find index
+    current_role_index = ROLES.index(st.session_state.user_role) if st.session_state.user_role in ROLES else None
+
     selected_role = st.radio(
         "Select your role:",
         options=ROLES,
         key="role_selector",
-        # index=0 # Default selection
-        index=ROLES.index(st.session_state.user_role) if st.session_state.user_role else 0,
+        index=current_role_index, # Set index based on current state or None
         # horizontal=True # Optional: make radio buttons horizontal
     )
 
-    # Update role and RAG chain if role changes
-    if selected_role != st.session_state.user_role:
+    # Update role and RAG chain if role changes *and* a role is actually selected
+    if selected_role and selected_role != st.session_state.user_role:
         st.session_state.user_role = selected_role
-        st.session_state.chat_history = []  # Clear history on role change
-        st.session_state.show_ticket_form = False
-        if vector_store:  # Only create chain if vector store is ready
-            try:
-                st.session_state.rag_chain = get_rag_chain(st.session_state.user_role)
-                st.success(f"Role set to **{st.session_state.user_role}**. RAG chain updated.")
-                st.rerun()  # Rerun to clear main page state if needed
-            except Exception as e:
-                st.error(f"Error initializing RAG chain: {e}")
-                st.session_state.rag_chain = None  # Ensure it's None if error occurs
+        st.session_state.chat_history = [] # Clear history on role change
+        st.session_state.show_ticket_form = False # Hide ticket form
+        if vector_store: # Only create chain if vector store is ready
+             try:
+                 # Get the chain specifically for the newly selected role
+                 st.session_state.rag_chain = get_rag_chain(st.session_state.user_role)
+                 st.success(f"Role set to **{st.session_state.user_role}**. Assistant ready.")
+             except Exception as e:
+                  st.error(f"Error initializing RAG chain: {e}")
+                  st.session_state.rag_chain = None # Ensure it's None if error occurs
         else:
-            st.error("RAG system not available. Cannot process queries.")
-            st.session_state.rag_chain = None
+             st.error("RAG system not available. Cannot process queries.")
+             st.session_state.rag_chain = None
 
     st.divider()
     if not vector_store:
-        st.warning("RAG system failed to initialize. Please check logs and ensure documents are present.", icon="⚠️")
+         st.warning("RAG system failed to initialize. Please check logs.", icon="⚠️")
     elif not st.session_state.user_role:
-        st.warning("Please select your role to begin.", icon="👤")
+         st.info("Please select your role in the sidebar to start chatting.", icon="👤")
+
 
 # --- Chat Interface ---
 st.header("Chat")
 
 # Display chat history
-for message in st.session_state.chat_history:
+for i, message in enumerate(st.session_state.chat_history):
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
-        # Display feedback buttons for assistant messages if feedback exists
+        # Display feedback buttons for assistant messages if feedback state exists
         if message["role"] == "assistant" and "feedback" in message:
-            feedback_key = f"feedback_{message['msg_id']}"  # Unique key
-            # Show feedback status, but disable buttons after click
-            if message["feedback"]["rating"] == "👍":
-                st.button("👍", key=f"{feedback_key}_up_voted", disabled=True)
-                st.button("👎", key=f"{feedback_key}_down_disabled", disabled=True)
-            elif message["feedback"]["rating"] == "👎":
-                st.button("👍", key=f"{feedback_key}_up_disabled", disabled=True)
-                st.button("👎", key=f"{feedback_key}_down_voted", disabled=True)
+             feedback_state = message["feedback"]
+             # Ensure msg_id exists, default if necessary
+             msg_id = message.get("msg_id", f"msg_{i}")
+             feedback_key_base = f"feedback_{msg_id}"
 
-# Chat input
-if prompt := st.chat_input("Ask a question...",
-                           disabled=(not st.session_state.user_role or not st.session_state.rag_chain)):
+             # Show feedback status, but disable buttons after click
+             if feedback_state.get("rating") == "👍":
+                  st.button("👍", key=f"{feedback_key_base}_up_voted", disabled=True)
+                  st.button("👎", key=f"{feedback_key_base}_down_disabled", disabled=True)
+             elif feedback_state.get("rating") == "👎":
+                  st.button("👍", key=f"{feedback_key_base}_up_disabled", disabled=True)
+                  st.button("👎", key=f"{feedback_key_base}_down_voted", disabled=True)
+             # Add feedback buttons only if not yet rated
+             elif feedback_state.get("show") and feedback_state.get("rating") is None:
+                  col1, col2, _ = st.columns([1, 1, 10]) # Layout for buttons
+                  with col1:
+                     if st.button("👍", key=f"{feedback_key_base}_up"):
+                         record_feedback(st.session_state.user_role, message.get("question", ""), message["content"], "👍")
+                         # Update feedback state in chat history directly
+                         st.session_state.chat_history[i]["feedback"]["rating"] = "👍"
+                         st.success("Feedback saved!")
+                         time.sleep(1) # Show message briefly
+                         st.rerun() # Rerun to update button state
+                  with col2:
+                     if st.button("👎", key=f"{feedback_key_base}_down"):
+                         record_feedback(st.session_state.user_role, message.get("question", ""), message["content"], "👎")
+                         # Update feedback state in chat history directly
+                         st.session_state.chat_history[i]["feedback"]["rating"] = "👎"
+                         st.success("Feedback saved!")
+                         time.sleep(1)
+                         st.rerun()
+
+
+# Chat input - disable if role not selected or RAG chain failed
+chat_input_disabled = not st.session_state.user_role or not st.session_state.rag_chain
+if prompt := st.chat_input("Ask a question...", disabled=chat_input_disabled):
     st.session_state.last_question = prompt
-    st.session_state.show_ticket_form = False  # Hide ticket form when new question is asked
+    st.session_state.show_ticket_form = False # Hide ticket form when new question is asked
 
     # Add user message to history and display
     st.session_state.chat_history.append({"role": "user", "content": prompt})
@@ -96,31 +124,31 @@ if prompt := st.chat_input("Ask a question...",
         message_placeholder = st.empty()
         full_response = ""
 
-
         # Simulate typing effect (optional)
-        def stream_chars(text, delay=0.01):
-            for char in text:
-                yield char
-                time.sleep(delay)
-
+        # def stream_chars(text, delay=0.01): ...
 
         try:
             if st.session_state.rag_chain:
-                print(f"Invoking RAG chain for role '{st.session_state.user_role}' with question: '{prompt}'")
-                # Pass the question correctly based on how the chain expects input
-                response_stream = st.session_state.rag_chain.stream({"question": prompt})
+                 print(f"Invoking RAG chain for role '{st.session_state.user_role}' with question: '{prompt}'")
+                 # Pass the question as a dictionary, matching the chain's expected input
+                 # The RunnableLambda in the chain expects {"question": question_text} implicitly
+                 response_stream = st.session_state.rag_chain.stream(prompt) # Pass prompt directly if chain expects raw string
 
-                # Stream response character by character
-                streamed_text = ""
-                for chunk in response_stream:
-                    # Assuming chunk is a string piece from StrOutputParser
-                    streamed_text += chunk
-                    message_placeholder.markdown(streamed_text + "▌")  # Blinking cursor effect
-                full_response = streamed_text
-                message_placeholder.markdown(full_response)  # Final response
+                 # Or if the chain expects a dict:
+                 # response_stream = st.session_state.rag_chain.stream({"question": prompt})
+
+
+                 # Stream response character by character
+                 streamed_text = ""
+                 for chunk in response_stream:
+                     # Assuming chunk is a string piece from StrOutputParser
+                     streamed_text += chunk
+                     message_placeholder.markdown(streamed_text + "▌") # Blinking cursor effect
+                 full_response = streamed_text
+                 message_placeholder.markdown(full_response) # Final response
 
             else:
-                full_response = "Sorry, the knowledge assistant is not available right now."
+                full_response = "Sorry, the knowledge assistant is not available right now (chain not loaded)."
                 message_placeholder.markdown(full_response)
 
         except Exception as e:
@@ -128,57 +156,64 @@ if prompt := st.chat_input("Ask a question...",
             message_placeholder.error(full_response)
             print(f"Error during RAG chain invocation: {e}")
 
-        # Check if the response indicates inability to answer
-        # Add more sophisticated checks if needed (e.g., keywords like "don't know", "cannot find")
-        offer_ticket = False
-        if "don't have that information" in full_response.lower() or \
-                "no relevant documents found" in full_response.lower() or \
-                "cannot access that" in full_response.lower():  # Placeholder for explicit access denial
-            offer_ticket = True
-            st.session_state.show_ticket_form = True
 
-        # Add assistant response to history
-        msg_id = f"msg_{len(st.session_state.chat_history)}"  # Unique ID for feedback
+        # ---Ticket Trigger Logic ---
+        offer_ticket = False
+        response_lower = full_response.lower()
+        failure_phrases = [
+            "i cannot answer that question",
+            "based on the documents i can access", # Partial phrase check
+            "cannot answer that question", # More general
+            "don't have that information",
+            "unable to find information",
+            "cannot find information",
+            "no relevant documents found", # Exact phrase from format_docs
+            "no relevant documents were found or accessible", # Partial phrase
+            "knowledge base is currently unavailable", # From dummy chain error
+            "rag system could not be initialized" # From dummy chain error
+        ]
+
+        # Check if *any* of the failure phrases are substrings of the response
+        if any(phrase in response_lower for phrase in failure_phrases):
+             offer_ticket = True
+             # Optional: Log which phrase triggered it for debugging
+             matched_phrase = next((p for p in failure_phrases if p in response_lower), "N/A")
+             print(f"Ticket offered because response contained a failure phrase ('{matched_phrase}'): '{full_response[:100]}...'")
+
+        # Set the state variable to control the ticket form visibility
+        if offer_ticket:
+            st.session_state.show_ticket_form = True
+        # --- End Updated Ticket Trigger Logic ---
+
+        # Add assistant response to history including ticket/feedback state
+        msg_id = f"msg_{len(st.session_state.chat_history)}"
         st.session_state.chat_history.append({
             "role": "assistant",
             "content": full_response,
             "msg_id": msg_id,
-            "question": prompt,  # Store question with answer for feedback context
-            "offer_ticket": offer_ticket,
-            "feedback": {"show": True, "rating": None}  # Add feedback state
+            "question": prompt, # Store question with answer for feedback/ticket context
+            "offer_ticket": offer_ticket, # Store whether ticket should be offered
+            "feedback": {"show": True, "rating": None} # Initialize feedback state
         })
 
-        # Add feedback buttons immediately after response (only if feedback not yet given)
-        feedback_state = st.session_state.chat_history[-1]["feedback"]
-        if feedback_state["show"] and feedback_state["rating"] is None:
-            col1, col2, _ = st.columns([1, 1, 10])  # Layout for buttons
-            with col1:
-                if st.button("👍", key=f"up_{msg_id}"):
-                    record_feedback(st.session_state.user_role, prompt, full_response, "👍")
-                    st.session_state.chat_history[-1]["feedback"]["rating"] = "👍"
-                    st.success("Feedback saved!")
-                    time.sleep(1)  # Show message briefly
-                    st.rerun()  # Rerun to update button state
-            with col2:
-                if st.button("👎", key=f"down_{msg_id}"):
-                    record_feedback(st.session_state.user_role, prompt, full_response, "👎")
-                    st.session_state.chat_history[-1]["feedback"]["rating"] = "👎"
-                    st.success("Feedback saved!")
-                    time.sleep(1)
-                    st.rerun()
+        # Rerun to immediately show feedback buttons for the new message
+        st.rerun()
+
 
 # --- Ticket Creation Form ---
-if st.session_state.show_ticket_form:
+# Use .get() to safely access session state keys that might not be set initially
+if st.session_state.get("show_ticket_form", False):
     st.divider()
     st.subheader("Need More Help? Create a Ticket")
 
-    # Suggest team based on the last question
+    # Suggest team based on the last question asked
     suggested_team = suggest_ticket_team(st.session_state.last_question)
     try:
-        # Pre-select suggested team in dropdown
+        # Pre-select suggested team in dropdown if it exists in the list
         default_index = TICKET_TEAMS.index(suggested_team)
     except ValueError:
-        default_index = TICKET_TEAMS.index("General")  # Fallback if suggested team isn't in the list
+        # Fallback to 'General' if suggested team isn't valid (e.g., no keywords matched)
+        default_index = TICKET_TEAMS.index("General") if "General" in TICKET_TEAMS else 0
 
     selected_team = st.selectbox(
         "Select the team to route your ticket to:",
@@ -188,8 +223,11 @@ if st.session_state.show_ticket_form:
     )
 
     # Simple summary of chat history (e.g., last few exchanges)
-    history_summary = "\n".join([f"{msg['role'].capitalize()}: {msg['content'][:100]}..."  # Truncate long messages
-                                 for msg in st.session_state.chat_history[-5:]])  # Last 5 messages
+    history_summary = "\n".join([f"{msg['role'].capitalize()}: {msg['content'][:150]}..." # Truncate long messages slightly more
+                                 for msg in st.session_state.chat_history[-5:]]) # Last 5 messages max
+
+    st.text_area("Ticket Details (Question & Chat Summary):", value=f"Question: {st.session_state.last_question}\n\nRecent Chat:\n{history_summary}", height=200, disabled=True)
+
 
     if st.button("Submit Ticket", key="submit_ticket_btn"):
         success = create_ticket(
@@ -201,8 +239,17 @@ if st.session_state.show_ticket_form:
         )
         if success:
             st.success(f"Ticket submitted successfully to the **{selected_team}** team! They will follow up.")
-            st.session_state.show_ticket_form = False  # Hide form after submission
-            time.sleep(2)  # Show success message
-            st.rerun()
+            st.session_state.show_ticket_form = False # Hide form after submission
+            # Keep last question
+            time.sleep(2) # Show success message briefly
+            st.rerun() # Rerun to hide the form and update UI
         else:
             st.error("Failed to submit the ticket. Please try again or contact support directly.")
+
+# --- Add a footer or sidebar note about the model being used ---
+# Placed here to be at the bottom or in sidebar
+with st.sidebar:
+     st.divider()
+     st.caption(f"Powered by: {LLM_MODEL}")
+     if not vector_store:
+          st.caption("Vector Store Status: Offline")

--- a/app.py
+++ b/app.py
@@ -1,0 +1,208 @@
+import streamlit as st
+import time  # For simulating typing effect
+
+# Import functions from other modules
+from config import ROLES, TICKET_TEAMS
+from rag_processor import get_rag_chain, vector_store  # Import vector_store to check if initialized
+from ticket_system import suggest_ticket_team, create_ticket
+from feedback_system import record_feedback
+
+# --- Streamlit Page Configuration ---
+st.set_page_config(page_title="Internal Knowledge Assistant PoC", layout="wide")
+st.title("🤖 Internal Knowledge Assistant PoC")
+st.caption("Ask questions about company policies, projects, and procedures.")
+
+# --- Initialize Database ---
+# (Done implicitly by importing database_utils in other modules)
+
+# --- Mock Login & Role Selection ---
+if 'user_role' not in st.session_state:
+    st.session_state.user_role = None
+if 'rag_chain' not in st.session_state:
+    st.session_state.rag_chain = None
+if 'show_ticket_form' not in st.session_state:
+    st.session_state.show_ticket_form = False
+if 'last_question' not in st.session_state:
+    st.session_state.last_question = ""
+if 'chat_history' not in st.session_state:
+    st.session_state.chat_history = []  # Store {'role': 'user'/'assistant', 'content': ...}
+
+# Sidebar for role selection
+with st.sidebar:
+    st.header("User Role")
+    selected_role = st.radio(
+        "Select your role:",
+        options=ROLES,
+        key="role_selector",
+        # index=0 # Default selection
+        index=ROLES.index(st.session_state.user_role) if st.session_state.user_role else 0,
+        # horizontal=True # Optional: make radio buttons horizontal
+    )
+
+    # Update role and RAG chain if role changes
+    if selected_role != st.session_state.user_role:
+        st.session_state.user_role = selected_role
+        st.session_state.chat_history = []  # Clear history on role change
+        st.session_state.show_ticket_form = False
+        if vector_store:  # Only create chain if vector store is ready
+            try:
+                st.session_state.rag_chain = get_rag_chain(st.session_state.user_role)
+                st.success(f"Role set to **{st.session_state.user_role}**. RAG chain updated.")
+                st.rerun()  # Rerun to clear main page state if needed
+            except Exception as e:
+                st.error(f"Error initializing RAG chain: {e}")
+                st.session_state.rag_chain = None  # Ensure it's None if error occurs
+        else:
+            st.error("RAG system not available. Cannot process queries.")
+            st.session_state.rag_chain = None
+
+    st.divider()
+    if not vector_store:
+        st.warning("RAG system failed to initialize. Please check logs and ensure documents are present.", icon="⚠️")
+    elif not st.session_state.user_role:
+        st.warning("Please select your role to begin.", icon="👤")
+
+# --- Chat Interface ---
+st.header("Chat")
+
+# Display chat history
+for message in st.session_state.chat_history:
+    with st.chat_message(message["role"]):
+        st.markdown(message["content"])
+        # Display feedback buttons for assistant messages if feedback exists
+        if message["role"] == "assistant" and "feedback" in message:
+            feedback_key = f"feedback_{message['msg_id']}"  # Unique key
+            # Show feedback status, but disable buttons after click
+            if message["feedback"]["rating"] == "👍":
+                st.button("👍", key=f"{feedback_key}_up_voted", disabled=True)
+                st.button("👎", key=f"{feedback_key}_down_disabled", disabled=True)
+            elif message["feedback"]["rating"] == "👎":
+                st.button("👍", key=f"{feedback_key}_up_disabled", disabled=True)
+                st.button("👎", key=f"{feedback_key}_down_voted", disabled=True)
+
+# Chat input
+if prompt := st.chat_input("Ask a question...",
+                           disabled=(not st.session_state.user_role or not st.session_state.rag_chain)):
+    st.session_state.last_question = prompt
+    st.session_state.show_ticket_form = False  # Hide ticket form when new question is asked
+
+    # Add user message to history and display
+    st.session_state.chat_history.append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    # Get response from RAG chain
+    with st.chat_message("assistant"):
+        message_placeholder = st.empty()
+        full_response = ""
+
+
+        # Simulate typing effect (optional)
+        def stream_chars(text, delay=0.01):
+            for char in text:
+                yield char
+                time.sleep(delay)
+
+
+        try:
+            if st.session_state.rag_chain:
+                print(f"Invoking RAG chain for role '{st.session_state.user_role}' with question: '{prompt}'")
+                # Pass the question correctly based on how the chain expects input
+                response_stream = st.session_state.rag_chain.stream({"question": prompt})
+
+                # Stream response character by character
+                streamed_text = ""
+                for chunk in response_stream:
+                    # Assuming chunk is a string piece from StrOutputParser
+                    streamed_text += chunk
+                    message_placeholder.markdown(streamed_text + "▌")  # Blinking cursor effect
+                full_response = streamed_text
+                message_placeholder.markdown(full_response)  # Final response
+
+            else:
+                full_response = "Sorry, the knowledge assistant is not available right now."
+                message_placeholder.markdown(full_response)
+
+        except Exception as e:
+            full_response = f"An error occurred: {e}"
+            message_placeholder.error(full_response)
+            print(f"Error during RAG chain invocation: {e}")
+
+        # Check if the response indicates inability to answer
+        # Add more sophisticated checks if needed (e.g., keywords like "don't know", "cannot find")
+        offer_ticket = False
+        if "don't have that information" in full_response.lower() or \
+                "no relevant documents found" in full_response.lower() or \
+                "cannot access that" in full_response.lower():  # Placeholder for explicit access denial
+            offer_ticket = True
+            st.session_state.show_ticket_form = True
+
+        # Add assistant response to history
+        msg_id = f"msg_{len(st.session_state.chat_history)}"  # Unique ID for feedback
+        st.session_state.chat_history.append({
+            "role": "assistant",
+            "content": full_response,
+            "msg_id": msg_id,
+            "question": prompt,  # Store question with answer for feedback context
+            "offer_ticket": offer_ticket,
+            "feedback": {"show": True, "rating": None}  # Add feedback state
+        })
+
+        # Add feedback buttons immediately after response (only if feedback not yet given)
+        feedback_state = st.session_state.chat_history[-1]["feedback"]
+        if feedback_state["show"] and feedback_state["rating"] is None:
+            col1, col2, _ = st.columns([1, 1, 10])  # Layout for buttons
+            with col1:
+                if st.button("👍", key=f"up_{msg_id}"):
+                    record_feedback(st.session_state.user_role, prompt, full_response, "👍")
+                    st.session_state.chat_history[-1]["feedback"]["rating"] = "👍"
+                    st.success("Feedback saved!")
+                    time.sleep(1)  # Show message briefly
+                    st.rerun()  # Rerun to update button state
+            with col2:
+                if st.button("👎", key=f"down_{msg_id}"):
+                    record_feedback(st.session_state.user_role, prompt, full_response, "👎")
+                    st.session_state.chat_history[-1]["feedback"]["rating"] = "👎"
+                    st.success("Feedback saved!")
+                    time.sleep(1)
+                    st.rerun()
+
+# --- Ticket Creation Form ---
+if st.session_state.show_ticket_form:
+    st.divider()
+    st.subheader("Need More Help? Create a Ticket")
+
+    # Suggest team based on the last question
+    suggested_team = suggest_ticket_team(st.session_state.last_question)
+    try:
+        # Pre-select suggested team in dropdown
+        default_index = TICKET_TEAMS.index(suggested_team)
+    except ValueError:
+        default_index = TICKET_TEAMS.index("General")  # Fallback if suggested team isn't in the list
+
+    selected_team = st.selectbox(
+        "Select the team to route your ticket to:",
+        options=TICKET_TEAMS,
+        index=default_index,
+        key="ticket_team_select"
+    )
+
+    # Simple summary of chat history (e.g., last few exchanges)
+    history_summary = "\n".join([f"{msg['role'].capitalize()}: {msg['content'][:100]}..."  # Truncate long messages
+                                 for msg in st.session_state.chat_history[-5:]])  # Last 5 messages
+
+    if st.button("Submit Ticket", key="submit_ticket_btn"):
+        success = create_ticket(
+            user_role=st.session_state.user_role,
+            question=st.session_state.last_question,
+            chat_history_summary=history_summary,
+            suggested_team=suggested_team,
+            selected_team=selected_team
+        )
+        if success:
+            st.success(f"Ticket submitted successfully to the **{selected_team}** team! They will follow up.")
+            st.session_state.show_ticket_form = False  # Hide form after submission
+            time.sleep(2)  # Show success message
+            st.rerun()
+        else:
+            st.error("Failed to submit the ticket. Please try again or contact support directly.")

--- a/app.py
+++ b/app.py
@@ -1,24 +1,21 @@
 import streamlit as st
 import time # For simulating typing effect
 
-# Import functions from other modules
-from config import ROLES, TICKET_TEAMS, LLM_MODEL
-# Import vector_store check and get_rag_chain
-from rag_processor import get_rag_chain, vector_store
+# Import functions and configurations
+from config import ROLES, TICKET_TEAMS, LLM_MODEL # Use lists directly from config
+from rag_processor import get_rag_chain, vector_store # Import check and function
 from ticket_system import suggest_ticket_team, create_ticket
 from feedback_system import record_feedback
 
 # --- Streamlit Page Configuration ---
-st.set_page_config(page_title="Internal Knowledge Assistant PoC", layout="wide")
-st.title("🤖 Internal Knowledge Assistant PoC")
-st.caption("Ask questions about company policies, projects, and procedures.")
+st.set_page_config(page_title="Company Knowledge Assistant PoC", layout="wide")
+st.title("🤖 Company Knowledge Assistant PoC")
+st.caption("Ask questions about company information, policies, and procedures.")
 
-
-# --- Mock Login & Role Selection ---
-# Initialize session state variables if they don't exist
-default_role = ROLES[0] # Default to the first role in the list, e.g., 'staff'
+# --- Session State Initialization ---
+# Ensure session state keys exist
 if 'user_role' not in st.session_state:
-    st.session_state.user_role = None # Start with no role selected initially
+    st.session_state.user_role = None # Start without a role selected
 if 'rag_chain' not in st.session_state:
      st.session_state.rag_chain = None
 if 'show_ticket_form' not in st.session_state:
@@ -26,209 +23,243 @@ if 'show_ticket_form' not in st.session_state:
 if 'last_question' not in st.session_state:
     st.session_state.last_question = ""
 if 'chat_history' not in st.session_state:
-    st.session_state.chat_history = [] # Store {'role': 'user'/'assistant', 'content': ...}
+    st.session_state.chat_history = []
 
-# Sidebar for role selection
+# --- Sidebar ---
 with st.sidebar:
     st.header("User Role")
-    # Use index=None for initial state if user_role is None, otherwise find index
+    # Find the index of the current role for the radio button default
     current_role_index = ROLES.index(st.session_state.user_role) if st.session_state.user_role in ROLES else None
 
     selected_role = st.radio(
         "Select your role:",
-        options=ROLES,
+        options=ROLES, # Use roles defined in config.py
         key="role_selector",
-        index=current_role_index, # Set index based on current state or None
-        # horizontal=True # Optional: make radio buttons horizontal
+        index=current_role_index, # Set default based on current state
     )
 
-    # Update role and RAG chain if role changes *and* a role is actually selected
+    # Handle role change
     if selected_role and selected_role != st.session_state.user_role:
+        print(f"Role changed from {st.session_state.user_role} to {selected_role}")
         st.session_state.user_role = selected_role
-        st.session_state.chat_history = [] # Clear history on role change
-        st.session_state.show_ticket_form = False # Hide ticket form
-        if vector_store: # Only create chain if vector store is ready
+        # Reset state on role change
+        st.session_state.chat_history = []
+        st.session_state.show_ticket_form = False
+        st.session_state.last_question = ""
+        st.session_state.rag_chain = None # Reset chain
+
+        if vector_store:
              try:
-                 # Get the chain specifically for the newly selected role
+                 # Get a new RAG chain configured for the selected role
                  st.session_state.rag_chain = get_rag_chain(st.session_state.user_role)
-                 st.success(f"Role set to **{st.session_state.user_role}**. Assistant ready.")
+                 st.success(f"Role set to **{st.session_state.user_role}**. Ready to chat.")
              except Exception as e:
-                  st.error(f"Error initializing RAG chain: {e}")
-                  st.session_state.rag_chain = None # Ensure it's None if error occurs
+                  st.error(f"Error initializing assistant for role '{selected_role}': {e}")
+                  st.session_state.rag_chain = None
         else:
-             st.error("RAG system not available. Cannot process queries.")
+             st.error("Knowledge base connection failed.")
              st.session_state.rag_chain = None
 
-    st.divider()
-    if not vector_store:
-         st.warning("RAG system failed to initialize. Please check logs.", icon="⚠️")
-    elif not st.session_state.user_role:
-         st.info("Please select your role in the sidebar to start chatting.", icon="👤")
+        # Rerun to update the main page state after role change
+        st.rerun()
 
+    st.divider()
+    # Display status messages
+    if not vector_store:
+         st.warning("Knowledge Base: Offline.", icon="⚠️")
+    elif not st.session_state.user_role:
+         st.info("Please select your role to start.", icon="👤")
+    else:
+         st.info(f"Current Role: **{st.session_state.user_role}**") # Confirm selected role
+
+    # Display backend info
+    st.divider()
+    st.caption(f"Model: {LLM_MODEL}")
+    st.caption(f"Vector DB: {'Chroma' if vector_store else 'Offline'}")
 
 # --- Chat Interface ---
-st.header("Chat")
+st.header("Chat Assistant")
 
 # Display chat history
 for i, message in enumerate(st.session_state.chat_history):
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
-        # Display feedback buttons for assistant messages if feedback state exists
+        # Display feedback buttons for previous assistant messages if applicable
         if message["role"] == "assistant" and "feedback" in message:
              feedback_state = message["feedback"]
-             # Ensure msg_id exists, default if necessary
              msg_id = message.get("msg_id", f"msg_{i}")
              feedback_key_base = f"feedback_{msg_id}"
 
-             # Show feedback status, but disable buttons after click
+             # Show feedback status if already rated
              if feedback_state.get("rating") == "👍":
                   st.button("👍", key=f"{feedback_key_base}_up_voted", disabled=True)
                   st.button("👎", key=f"{feedback_key_base}_down_disabled", disabled=True)
              elif feedback_state.get("rating") == "👎":
                   st.button("👍", key=f"{feedback_key_base}_up_disabled", disabled=True)
                   st.button("👎", key=f"{feedback_key_base}_down_voted", disabled=True)
-             # Add feedback buttons only if not yet rated
+             # Show buttons if feedback is pending
              elif feedback_state.get("show") and feedback_state.get("rating") is None:
-                  col1, col2, _ = st.columns([1, 1, 10]) # Layout for buttons
+                  col1, col2, _ = st.columns([1, 1, 10])
                   with col1:
                      if st.button("👍", key=f"{feedback_key_base}_up"):
                          record_feedback(st.session_state.user_role, message.get("question", ""), message["content"], "👍")
-                         # Update feedback state in chat history directly
-                         st.session_state.chat_history[i]["feedback"]["rating"] = "👍"
-                         st.success("Feedback saved!")
-                         time.sleep(1) # Show message briefly
-                         st.rerun() # Rerun to update button state
+                         st.session_state.chat_history[i]["feedback"]["rating"] = "👍" # Update state
+                         st.toast("Feedback saved!", icon="✅")
+                         time.sleep(0.5)
+                         st.rerun()
                   with col2:
                      if st.button("👎", key=f"{feedback_key_base}_down"):
                          record_feedback(st.session_state.user_role, message.get("question", ""), message["content"], "👎")
-                         # Update feedback state in chat history directly
-                         st.session_state.chat_history[i]["feedback"]["rating"] = "👎"
-                         st.success("Feedback saved!")
-                         time.sleep(1)
+                         st.session_state.chat_history[i]["feedback"]["rating"] = "👎" # Update state
+                         st.toast("Feedback saved!", icon="✅")
+                         time.sleep(0.5)
                          st.rerun()
 
 
-# Chat input - disable if role not selected or RAG chain failed
+# Chat input area
 chat_input_disabled = not st.session_state.user_role or not st.session_state.rag_chain
-if prompt := st.chat_input("Ask a question...", disabled=chat_input_disabled):
+if prompt := st.chat_input("Ask your question here...", disabled=chat_input_disabled, key="chat_input"):
     st.session_state.last_question = prompt
-    st.session_state.show_ticket_form = False # Hide ticket form when new question is asked
+    # Hide ticket form when a new question is asked
+    st.session_state.show_ticket_form = False
 
-    # Add user message to history and display
+    # Display user message
     st.session_state.chat_history.append({"role": "user", "content": prompt})
     with st.chat_message("user"):
         st.markdown(prompt)
 
-    # Get response from RAG chain
+    # Process and display assistant response
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
+        message_placeholder.markdown("Thinking...▌")  # Initial placeholder
+
         full_response = ""
-
-        # Simulate typing effect (optional)
-        # def stream_chars(text, delay=0.01): ...
-
         try:
             if st.session_state.rag_chain:
-                 print(f"Invoking RAG chain for role '{st.session_state.user_role}' with question: '{prompt}'")
-                 # Pass the question as a dictionary, matching the chain's expected input
-                 # The RunnableLambda in the chain expects {"question": question_text} implicitly
-                 response_stream = st.session_state.rag_chain.stream(prompt) # Pass prompt directly if chain expects raw string
+                print(f"Invoking RAG chain for role '{st.session_state.user_role}' with question: '{prompt}'")
+                response_stream = st.session_state.rag_chain.stream(prompt)
 
-                 # Or if the chain expects a dict:
-                 # response_stream = st.session_state.rag_chain.stream({"question": prompt})
-
-
-                 # Stream response character by character
-                 streamed_text = ""
-                 for chunk in response_stream:
-                     # Assuming chunk is a string piece from StrOutputParser
-                     streamed_text += chunk
-                     message_placeholder.markdown(streamed_text + "▌") # Blinking cursor effect
-                 full_response = streamed_text
-                 message_placeholder.markdown(full_response) # Final response
+                streamed_text = ""
+                for chunk in response_stream:
+                    streamed_text += chunk
+                    message_placeholder.markdown(streamed_text + "▌")
+                full_response = streamed_text
+                # message_placeholder.markdown(full_response) # <-- Display happens *after* cleanup now
 
             else:
-                full_response = "Sorry, the knowledge assistant is not available right now (chain not loaded)."
-                message_placeholder.markdown(full_response)
+                full_response = "Assistant is currently unavailable..."
+                # message_placeholder.warning(full_response) # <-- Display happens *after* potential cleanup
 
         except Exception as e:
             full_response = f"An error occurred: {e}"
-            message_placeholder.error(full_response)
+            # message_placeholder.error(full_response) # <-- Display happens *after* potential cleanup
             print(f"Error during RAG chain invocation: {e}")
 
+        # --- START: Add <think> tag cleanup ---
+        original_llm_output = full_response  # Keep original for potential debugging
+        if "</think>" in full_response:
+            print(f"Original LLM output includes </think> tag: {original_llm_output[:150]}...")
+            # Split by the closing tag and take the last part
+            cleaned_response = full_response.split("</think>")[-1].strip()
 
-        # ---Ticket Trigger Logic ---
+            # Optional: Handle cases where cleanup might leave an empty string
+            if not cleaned_response:
+                print(
+                    "Warning: Cleanup resulted in empty string. Falling back to original response minus tags (simple approach).")
+                # A simple fallback, might need refinement based on observed LLM behavior
+                import re
+
+                cleaned_response = re.sub(r"<think>.*?</think>", "", full_response, flags=re.DOTALL).strip()
+                if not cleaned_response:  # If still empty, use original
+                    cleaned_response = original_llm_output
+
+            full_response = cleaned_response  # Update full_response with the cleaned version
+            print(f"Cleaned LLM response: {full_response[:150]}...")
+        # --- END: Add <think> tag cleanup ---
+
+        # Now display the potentially cleaned response
+        # Determine message type based on original or error status
+        if "An error occurred:" in original_llm_output:
+            message_placeholder.error(full_response)
+        elif "Assistant is currently unavailable" in original_llm_output:
+            message_placeholder.warning(full_response)
+        else:
+            message_placeholder.markdown(full_response)
+
+        # --- Ticket Trigger Logic ---
+        # This logic now uses the potentially cleaned 'full_response'
         offer_ticket = False
         response_lower = full_response.lower()
         failure_phrases = [
+            # ... (keep your list of failure phrases) ...
             "i cannot answer that question",
-            "based on the documents i can access", # Partial phrase check
-            "cannot answer that question", # More general
+            "based on the documents i can access",
+            "cannot answer that question",
             "don't have that information",
             "unable to find information",
             "cannot find information",
-            "no relevant documents found", # Exact phrase from format_docs
-            "no relevant documents were found or accessible", # Partial phrase
-            "knowledge base is currently unavailable", # From dummy chain error
-            "rag system could not be initialized" # From dummy chain error
+            "no relevant documents found",
+            "no relevant documents were found or accessible",
+            "knowledge base is currently unavailable",
+            "rag system could not be initialized",
+            "error: invalid role"
         ]
-
-        # Check if *any* of the failure phrases are substrings of the response
+        # ... (rest of ticket logic remains the same) ...
         if any(phrase in response_lower for phrase in failure_phrases):
-             offer_ticket = True
-             # Optional: Log which phrase triggered it for debugging
-             matched_phrase = next((p for p in failure_phrases if p in response_lower), "N/A")
-             print(f"Ticket offered because response contained a failure phrase ('{matched_phrase}'): '{full_response[:100]}...'")
+            offer_ticket = True
+            # ...
 
-        # Set the state variable to control the ticket form visibility
         if offer_ticket:
             st.session_state.show_ticket_form = True
-        # --- End Updated Ticket Trigger Logic ---
+        # --- End Ticket Trigger Logic ---
 
-        # Add assistant response to history including ticket/feedback state
+        # Store assistant message details in history
+        # Crucially, store the *cleaned* full_response here
         msg_id = f"msg_{len(st.session_state.chat_history)}"
         st.session_state.chat_history.append({
-            "role": "assistant",
-            "content": full_response,
+            "role": "assistant", "content": full_response,  # <-- Store cleaned response
             "msg_id": msg_id,
-            "question": prompt, # Store question with answer for feedback/ticket context
-            "offer_ticket": offer_ticket, # Store whether ticket should be offered
-            "feedback": {"show": True, "rating": None} # Initialize feedback state
+            "question": prompt,
+            "offer_ticket": offer_ticket,
+            "feedback": {"show": True, "rating": None}
         })
 
-        # Rerun to immediately show feedback buttons for the new message
         st.rerun()
 
 
 # --- Ticket Creation Form ---
-# Use .get() to safely access session state keys that might not be set initially
+# Display form if the 'show_ticket_form' state is True
 if st.session_state.get("show_ticket_form", False):
     st.divider()
-    st.subheader("Need More Help? Create a Ticket")
+    st.subheader("Request Further Assistance?")
+    st.caption("If the assistant couldn't help, you can create a ticket for the appropriate team.")
 
-    # Suggest team based on the last question asked
+    # Suggest team based on the last question
     suggested_team = suggest_ticket_team(st.session_state.last_question)
     try:
-        # Pre-select suggested team in dropdown if it exists in the list
+        # Find index of suggested team, fallback to General
         default_index = TICKET_TEAMS.index(suggested_team)
     except ValueError:
-        # Fallback to 'General' if suggested team isn't valid (e.g., no keywords matched)
         default_index = TICKET_TEAMS.index("General") if "General" in TICKET_TEAMS else 0
 
+    # Team selection dropdown
     selected_team = st.selectbox(
-        "Select the team to route your ticket to:",
-        options=TICKET_TEAMS,
+        "Select the most relevant team:",
+        options=TICKET_TEAMS, # Use teams from config
         index=default_index,
         key="ticket_team_select"
     )
 
-    # Simple summary of chat history (e.g., last few exchanges)
-    history_summary = "\n".join([f"{msg['role'].capitalize()}: {msg['content'][:150]}..." # Truncate long messages slightly more
-                                 for msg in st.session_state.chat_history[-5:]]) # Last 5 messages max
+    # Prepare chat summary for the ticket
+    history_summary = "\n".join([f"{msg['role'].capitalize()}: {msg['content'][:150]}..." # Truncate long messages
+                                 for msg in st.session_state.chat_history[-5:]]) # Last 5 messages
 
-    st.text_area("Ticket Details (Question & Chat Summary):", value=f"Question: {st.session_state.last_question}\n\nRecent Chat:\n{history_summary}", height=200, disabled=True)
+    # Display ticket details (read-only)
+    st.text_area("Ticket Details (auto-filled):",
+                 value=f"User Role: {st.session_state.user_role}\nQuestion: {st.session_state.last_question}\n\nRecent Chat:\n{history_summary}",
+                 height=250, disabled=True, key="ticket_details_display")
 
-
+    # Submit button
     if st.button("Submit Ticket", key="submit_ticket_btn"):
         success = create_ticket(
             user_role=st.session_state.user_role,
@@ -238,18 +269,9 @@ if st.session_state.get("show_ticket_form", False):
             selected_team=selected_team
         )
         if success:
-            st.success(f"Ticket submitted successfully to the **{selected_team}** team! They will follow up.")
-            st.session_state.show_ticket_form = False # Hide form after submission
-            # Keep last question
-            time.sleep(2) # Show success message briefly
-            st.rerun() # Rerun to hide the form and update UI
+            st.success(f"Ticket submitted successfully to **{selected_team}**!")
+            st.session_state.show_ticket_form = False # Hide form
+            time.sleep(2.5) # Show success message
+            st.rerun() # Update UI
         else:
-            st.error("Failed to submit the ticket. Please try again or contact support directly.")
-
-# --- Add a footer or sidebar note about the model being used ---
-# Placed here to be at the bottom or in sidebar
-with st.sidebar:
-     st.divider()
-     st.caption(f"Powered by: {LLM_MODEL}")
-     if not vector_store:
-          st.caption("Vector Store Status: Offline")
+            st.error("Failed to submit the ticket. Please try again later.")

--- a/config.py
+++ b/config.py
@@ -14,11 +14,11 @@ DOCS_FOLDER = "sample_docs"
 ALLOWED_EXTENSIONS = [".txt", ".pdf"]
 
 # --- RAG Configuration ---
-VECTOR_STORE_PATH = "vector_store_db"
+# Use a directory name for ChromaDB persistence
+PERSIST_DIRECTORY = "chroma_db"
 CHUNK_SIZE = 500
 CHUNK_OVERLAP = 50
 EMBEDDING_MODEL = "all-MiniLM-L6-v2"
-# Make sure Ollama server is running and the model is pulled
 LLM_MODEL = "deepseek-r1:1.5b"
 
 # --- Ticket System Configuration ---
@@ -28,12 +28,14 @@ FEEDBACK_DB_PATH = "database/feedback.db"
 
 # Simple keyword mapping for team suggestions
 TICKET_KEYWORD_MAP = {
-    "hr": ["payroll", "leave", "benefits", "hiring", "policy", "pto"],
-    "it": ["laptop", "password", "software", "printer", "network", "login", "access"],
-    "product": ["feature", "roadmap", "sprint", "project", "omega"],
-    "legal": ["contract", "compliance", "nda"]
+    "hr": ["payroll", "leave", "benefits", "hiring", "policy", "pto", "salary"],
+    "it": ["laptop", "password", "software", "printer", "network", "login", "access", "computer", "wifi"],
+    "product": ["feature", "roadmap", "sprint", "project", "omega", "update"],
+    "legal": ["contract", "compliance", "nda", "agreement"]
 }
 
 # --- Create necessary directories ---
 os.makedirs(os.path.dirname(TICKET_DB_PATH), exist_ok=True)
 os.makedirs(os.path.dirname(FEEDBACK_DB_PATH), exist_ok=True)
+# Chroma will create its own directory if needed, but ensure parent exists if nested deeper
+# os.makedirs(PERSIST_DIRECTORY, exist_ok=True) # Chroma handles its own directory creation

--- a/config.py
+++ b/config.py
@@ -1,9 +1,14 @@
+# config.py
 import os
 
 # --- Role Configuration ---
-ROLES = ["staff", "hr", "manager"]
-# Define role hierarchy (higher number means more access)
+# Add 'customer' role
+ROLES = ["customer", "staff", "hr", "manager"]
+# Define role hierarchy (customer is lowest level 0)
+# 'public' is used as an alias for level 0 tagging in filenames
 ROLE_HIERARCHY = {
+    "customer": 0, # Lowest access level
+    "public": 0,   # Documents tagged '_public' get level 0
     "staff": 1,
     "hr": 2,
     "manager": 3
@@ -14,28 +19,32 @@ DOCS_FOLDER = "sample_docs"
 ALLOWED_EXTENSIONS = [".txt", ".pdf"]
 
 # --- RAG Configuration ---
-# Use a directory name for ChromaDB persistence
-PERSIST_DIRECTORY = "chroma_db"
+PERSIST_DIRECTORY = "chroma_db" # ChromaDB persistence path
 CHUNK_SIZE = 500
 CHUNK_OVERLAP = 50
 EMBEDDING_MODEL = "all-MiniLM-L6-v2"
-LLM_MODEL = "deepseek-r1:1.5b"
+# Ensure this matches the model tag you pulled and are running with Ollama
+LLM_MODEL = "deepseek-r1:1.5b" # Or your chosen model
 
 # --- Ticket System Configuration ---
-TICKET_TEAMS = ["HR", "IT", "Product", "Legal", "General"]
+# Add 'Customer Support' team
+TICKET_TEAMS = ["Customer Support", "HR", "IT", "Product", "Legal", "General"]
 TICKET_DB_PATH = "database/tickets.db"
 FEEDBACK_DB_PATH = "database/feedback.db"
 
 # Simple keyword mapping for team suggestions
+# Added specific keywords for Customer Support
 TICKET_KEYWORD_MAP = {
-    "hr": ["payroll", "leave", "benefits", "hiring", "policy", "pto", "salary"],
-    "it": ["laptop", "password", "software", "printer", "network", "login", "access", "computer", "wifi"],
-    "product": ["feature", "roadmap", "sprint", "project", "omega", "update"],
-    "legal": ["contract", "compliance", "nda", "agreement"]
+    # Map general customer issues to Customer Support
+    "customer support": ["account", "order", "website", "login", "purchase", "service", "product issue", "billing", "faq", "contact", "support"],
+    "hr": ["payroll", "leave", "benefits", "hiring", "policy", "pto", "salary", "employee"],
+    "it": ["laptop", "password", "software", "printer", "network", "access", "computer", "wifi", "system"],
+    "product": ["feature", "roadmap", "sprint", "project", "omega", "update", "deployment"],
+    "legal": ["contract", "compliance", "nda", "agreement", "terms", "policy"] # Legal might overlap with HR/General
 }
 
 # --- Create necessary directories ---
+# Ensure the parent directory for the databases exists
 os.makedirs(os.path.dirname(TICKET_DB_PATH), exist_ok=True)
 os.makedirs(os.path.dirname(FEEDBACK_DB_PATH), exist_ok=True)
-# Chroma will create its own directory if needed, but ensure parent exists if nested deeper
-# os.makedirs(PERSIST_DIRECTORY, exist_ok=True) # Chroma handles its own directory creation
+# ChromaDB will create its own directory defined by PERSIST_DIRECTORY

--- a/config.py
+++ b/config.py
@@ -1,0 +1,39 @@
+import os
+
+# --- Role Configuration ---
+ROLES = ["staff", "hr", "manager"]
+# Define role hierarchy (higher number means more access)
+ROLE_HIERARCHY = {
+    "staff": 1,
+    "hr": 2,
+    "manager": 3
+}
+
+# --- Document Configuration ---
+DOCS_FOLDER = "sample_docs"
+ALLOWED_EXTENSIONS = [".txt", ".pdf"]
+
+# --- RAG Configuration ---
+VECTOR_STORE_PATH = "vector_store_db"
+CHUNK_SIZE = 500
+CHUNK_OVERLAP = 50
+EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+# Make sure Ollama server is running and the model is pulled
+LLM_MODEL = "deepseek-r1:1.5b"
+
+# --- Ticket System Configuration ---
+TICKET_TEAMS = ["HR", "IT", "Product", "Legal", "General"]
+TICKET_DB_PATH = "database/tickets.db"
+FEEDBACK_DB_PATH = "database/feedback.db"
+
+# Simple keyword mapping for team suggestions
+TICKET_KEYWORD_MAP = {
+    "hr": ["payroll", "leave", "benefits", "hiring", "policy", "pto"],
+    "it": ["laptop", "password", "software", "printer", "network", "login", "access"],
+    "product": ["feature", "roadmap", "sprint", "project", "omega"],
+    "legal": ["contract", "compliance", "nda"]
+}
+
+# --- Create necessary directories ---
+os.makedirs(os.path.dirname(TICKET_DB_PATH), exist_ok=True)
+os.makedirs(os.path.dirname(FEEDBACK_DB_PATH), exist_ok=True)

--- a/database_utils.py
+++ b/database_utils.py
@@ -1,42 +1,49 @@
+# database_utils.py
 import sqlite3
 import datetime
 from config import TICKET_DB_PATH, FEEDBACK_DB_PATH
 
-
 def init_db():
     """Initializes the SQLite databases for tickets and feedback if they don't exist."""
     # Initialize Ticket DB
-    with sqlite3.connect(TICKET_DB_PATH) as conn:
-        cursor = conn.cursor()
-        cursor.execute('''
-            CREATE TABLE IF NOT EXISTS tickets (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                user_role TEXT,
-                question TEXT,
-                chat_history TEXT,
-                suggested_team TEXT,
-                selected_team TEXT,
-                status TEXT DEFAULT 'Open'
-            )
-        ''')
-        conn.commit()
+    try:
+        with sqlite3.connect(TICKET_DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS tickets (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    user_role TEXT,
+                    question TEXT,
+                    chat_history TEXT,
+                    suggested_team TEXT,
+                    selected_team TEXT,
+                    status TEXT DEFAULT 'Open'
+                )
+            ''')
+            conn.commit()
+            print(f"Ticket database initialized at {TICKET_DB_PATH}")
+    except sqlite3.Error as e:
+        print(f"Error initializing ticket database: {e}")
 
     # Initialize Feedback DB
-    with sqlite3.connect(FEEDBACK_DB_PATH) as conn:
-        cursor = conn.cursor()
-        cursor.execute('''
-            CREATE TABLE IF NOT EXISTS feedback (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                user_role TEXT,
-                question TEXT,
-                answer TEXT,
-                rating TEXT CHECK(rating IN ('👍', '👎'))
-            )
-        ''')
-        conn.commit()
-
+    try:
+        with sqlite3.connect(FEEDBACK_DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS feedback (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    user_role TEXT,
+                    question TEXT,
+                    answer TEXT,
+                    rating TEXT CHECK(rating IN ('👍', '👎'))
+                )
+            ''')
+            conn.commit()
+            print(f"Feedback database initialized at {FEEDBACK_DB_PATH}")
+    except sqlite3.Error as e:
+        print(f"Error initializing feedback database: {e}")
 
 def save_ticket(user_role, question, chat_history, suggested_team, selected_team):
     """Saves a new ticket to the database."""
@@ -53,7 +60,6 @@ def save_ticket(user_role, question, chat_history, suggested_team, selected_team
         print(f"Database error saving ticket: {e}")
         return False
 
-
 def save_feedback(user_role, question, answer, rating):
     """Saves user feedback to the database."""
     try:
@@ -69,6 +75,6 @@ def save_feedback(user_role, question, answer, rating):
         print(f"Database error saving feedback: {e}")
         return False
 
-
 # Initialize databases when this module is imported
+# This ensures tables are created when the app starts
 init_db()

--- a/database_utils.py
+++ b/database_utils.py
@@ -1,0 +1,74 @@
+import sqlite3
+import datetime
+from config import TICKET_DB_PATH, FEEDBACK_DB_PATH
+
+
+def init_db():
+    """Initializes the SQLite databases for tickets and feedback if they don't exist."""
+    # Initialize Ticket DB
+    with sqlite3.connect(TICKET_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS tickets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                user_role TEXT,
+                question TEXT,
+                chat_history TEXT,
+                suggested_team TEXT,
+                selected_team TEXT,
+                status TEXT DEFAULT 'Open'
+            )
+        ''')
+        conn.commit()
+
+    # Initialize Feedback DB
+    with sqlite3.connect(FEEDBACK_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS feedback (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                user_role TEXT,
+                question TEXT,
+                answer TEXT,
+                rating TEXT CHECK(rating IN ('👍', '👎'))
+            )
+        ''')
+        conn.commit()
+
+
+def save_ticket(user_role, question, chat_history, suggested_team, selected_team):
+    """Saves a new ticket to the database."""
+    try:
+        with sqlite3.connect(TICKET_DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                INSERT INTO tickets (user_role, question, chat_history, suggested_team, selected_team)
+                VALUES (?, ?, ?, ?, ?)
+            ''', (user_role, question, chat_history, suggested_team, selected_team))
+            conn.commit()
+        return True
+    except sqlite3.Error as e:
+        print(f"Database error saving ticket: {e}")
+        return False
+
+
+def save_feedback(user_role, question, answer, rating):
+    """Saves user feedback to the database."""
+    try:
+        with sqlite3.connect(FEEDBACK_DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                INSERT INTO feedback (user_role, question, answer, rating)
+                VALUES (?, ?, ?, ?)
+            ''', (user_role, question, answer, rating))
+            conn.commit()
+        return True
+    except sqlite3.Error as e:
+        print(f"Database error saving feedback: {e}")
+        return False
+
+
+# Initialize databases when this module is imported
+init_db()

--- a/feedback_system.py
+++ b/feedback_system.py
@@ -1,0 +1,12 @@
+from database_utils import save_feedback
+
+def record_feedback(user_role, question, answer, rating):
+    """Records user feedback."""
+    print(f"Recording feedback: {rating} for question: '{question[:50]}...'")
+    success = save_feedback(
+        user_role=user_role,
+        question=question,
+        answer=answer,
+        rating=rating
+    )
+    return success

--- a/feedback_system.py
+++ b/feedback_system.py
@@ -1,12 +1,15 @@
+# feedback_system.py
 from database_utils import save_feedback
 
 def record_feedback(user_role, question, answer, rating):
     """Records user feedback."""
-    print(f"Recording feedback: {rating} for question: '{question[:50]}...'")
+    print(f"Recording feedback: {rating} for question: '{question[:50]}...' by role '{user_role}'")
     success = save_feedback(
         user_role=user_role,
         question=question,
         answer=answer,
         rating=rating
     )
+    if not success:
+        print("Warning: Failed to save feedback to the database.")
     return success

--- a/rag_processor.py
+++ b/rag_processor.py
@@ -1,0 +1,199 @@
+import os
+import glob
+from langchain_community.document_loaders import PyPDFLoader, TextLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_community.embeddings import SentenceTransformerEmbeddings
+from langchain_community.vectorstores import FAISS
+from langchain_community.llms import Ollama
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.documents import Document
+
+from config import (
+    DOCS_FOLDER, ALLOWED_EXTENSIONS, ROLE_HIERARCHY,
+    VECTOR_STORE_PATH, CHUNK_SIZE, CHUNK_OVERLAP,
+    EMBEDDING_MODEL, LLM_MODEL
+)
+
+
+# --- Document Loading & Role Tagging ---
+
+def get_role_from_filename(filename):
+    """Extracts the minimum required role from the filename suffix."""
+    base = os.path.splitext(filename)[0]
+    parts = base.split('_')
+    if len(parts) > 1:
+        role_tag = parts[-1].lower()
+        if role_tag in ROLE_HIERARCHY:
+            return role_tag
+    return "staff"  # Default to lowest access if no valid tag
+
+
+def load_documents():
+    """Loads documents from DOCS_FOLDER, extracts role from filename, and adds metadata."""
+    print(f"Loading documents from: {DOCS_FOLDER}")
+    docs = []
+    for ext in ALLOWED_EXTENSIONS:
+        for filepath in glob.glob(os.path.join(DOCS_FOLDER, f"*{ext}")):
+            filename = os.path.basename(filepath)
+            role = get_role_from_filename(filename)
+            print(f" - Loading {filename} (Role: {role})")
+            try:
+                if ext == ".pdf":
+                    loader = PyPDFLoader(filepath)
+                elif ext == ".txt":
+                    loader = TextLoader(filepath)
+                else:
+                    continue  # Should not happen due to glob pattern
+
+                loaded_docs = loader.load()
+                # Add metadata (role and source) to each document page/chunk precursor
+                for doc in loaded_docs:
+                    doc.metadata["role"] = role
+                    doc.metadata["source"] = filename  # Keep track of original file
+                docs.extend(loaded_docs)
+            except Exception as e:
+                print(f"   Error loading {filename}: {e}")
+    print(f"Total documents loaded: {len(docs)}")
+    return docs
+
+
+# --- Text Splitting ---
+text_splitter = RecursiveCharacterTextSplitter(
+    chunk_size=CHUNK_SIZE,
+    chunk_overlap=CHUNK_OVERLAP
+)
+
+# --- Embeddings ---
+print(f"Loading embedding model: {EMBEDDING_MODEL}")
+embeddings = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
+print("Embedding model loaded.")
+
+# --- Vector Store ---
+vector_store = None
+
+
+def create_or_load_vector_store():
+    """Creates the vector store if it doesn't exist, otherwise loads it."""
+    global vector_store
+    if os.path.exists(VECTOR_STORE_PATH):
+        print(f"Loading existing vector store from: {VECTOR_STORE_PATH}")
+        vector_store = FAISS.load_local(VECTOR_STORE_PATH, embeddings,
+                                        allow_dangerous_deserialization=True)  # Be careful with this in production
+        print("Vector store loaded.")
+    else:
+        print("Creating new vector store...")
+        documents = load_documents()
+        if not documents:
+            print("No documents found to create vector store. Aborting.")
+            return None
+
+        chunks = text_splitter.split_documents(documents)
+        # Ensure metadata is preserved during splitting
+        # RecursiveCharacterTextSplitter usually does this automatically
+        print(f"Split documents into {len(chunks)} chunks.")
+
+        # Example check for metadata persistence
+        if chunks and 'role' not in chunks[0].metadata:
+            print("Warning: Metadata might not be preserved correctly during splitting!")
+
+        print("Creating FAISS index...")
+        vector_store = FAISS.from_documents(chunks, embeddings)
+        print("FAISS index created.")
+        print(f"Saving vector store to: {VECTOR_STORE_PATH}")
+        vector_store.save_local(VECTOR_STORE_PATH)
+        print("Vector store saved.")
+    return vector_store
+
+
+# Ensure vector store is loaded/created when module is imported
+vector_store = create_or_load_vector_store()
+
+# --- LLM and RAG Chain ---
+
+if vector_store:
+    print(f"Initializing LLM: {LLM_MODEL}")
+    llm = Ollama(model=LLM_MODEL)
+    print("LLM initialized.")
+
+    # Define the RAG prompt template
+    # Explicitly telling the LLM to use *only* the context is crucial for reducing hallucinations.
+    template = """
+        You are an internal knowledge assistant for African Institute for Artificial Intelligence (AI4AI).
+        Answer the question(s) based ONLY on the following context provided. Do not output your reasoning or expose context information
+        If the context is empty, states 'No relevant documents were found or accessible for your role. Kindly open a ticket', or does not contain the answer, state clearly: 'Based on the documents I can access, I cannot answer that question. Kindly open a ticket'
+        Do not make up information or use external knowledge.
+        Be concise and helpful.
+
+        Context:
+        {context}
+
+        Question:
+        {question}
+
+        Answer:
+        """
+    prompt = ChatPromptTemplate.from_template(template)
+
+    # Output parser
+    output_parser = StrOutputParser()
+
+
+    def filter_documents_by_role(docs, user_role):
+        """Filters retrieved documents based on user's role hierarchy."""
+        user_level = ROLE_HIERARCHY.get(user_role, 0)
+        allowed_docs = []
+        print(f"Filtering {len(docs)} retrieved docs for user role '{user_role}' (level {user_level})...")
+        for doc in docs:
+            doc_role = doc.metadata.get("role", "staff")  # Default to lowest if missing
+            doc_level = ROLE_HIERARCHY.get(doc_role, 0)
+            if user_level >= doc_level:
+                print(
+                    f"  - Allowing doc from '{doc.metadata.get('source', 'N/A')}' (role: {doc_role}, level: {doc_level})")
+                allowed_docs.append(doc)
+            else:
+                print(
+                    f"  - Denying doc from '{doc.metadata.get('source', 'N/A')}' (role: {doc_role}, level: {doc_level}) - Requires higher role.")
+        print(f"Allowed {len(allowed_docs)} docs after filtering.")
+        return allowed_docs
+
+
+    def format_docs(docs):
+        """Helper function to format documents for the prompt context."""
+        if not docs:
+            return "No relevant documents found or accessible."
+        # Include source and role info in context for clarity (optional but helpful for debugging)
+        # return "\n\n".join(f"Source: {doc.metadata.get('source', 'N/A')}, Role: {doc.metadata.get('role', 'N/A')}\nContent: {doc.page_content}" for doc in docs)
+        # Simpler version for final prompt:
+        return "\n\n".join(doc.page_content for doc in docs)
+
+
+    # Define the RAG chain
+    def get_rag_chain(user_role):
+        """Creates and returns the RAG chain, incorporating role-based filtering."""
+        if not vector_store:
+            print("Error: Vector store not available.")
+            # Return a dummy chain or raise an error
+            return RunnablePassthrough()  # Placeholder that does nothing useful
+
+        retriever = vector_store.as_retriever(search_kwargs={"k": 5})  # Retrieve top 5 chunks initially
+
+        # Chain definition
+        rag_chain = (
+                {"context": (lambda x: x['question']) | retriever | (
+                    lambda docs: filter_documents_by_role(docs, user_role)) | format_docs,
+                 "question": RunnablePassthrough()}
+                | prompt
+                | llm
+                | output_parser
+        )
+        return rag_chain
+
+else:
+    print("Cannot initialize RAG chain because vector store failed to load/create.")
+
+
+    # Define a placeholder function or handle this error appropriately in the app
+    def get_rag_chain(user_role):
+        raise RuntimeError("RAG system could not be initialized. Check document loading and vector store creation.")

--- a/rag_processor.py
+++ b/rag_processor.py
@@ -1,199 +1,215 @@
+# rag_processor.py
 import os
 import glob
+from langchain_community.vectorstores import Chroma
 from langchain_community.document_loaders import PyPDFLoader, TextLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import SentenceTransformerEmbeddings
-from langchain_community.vectorstores import FAISS
 from langchain_community.llms import Ollama
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.runnables import RunnablePassthrough
+from langchain_core.runnables import RunnablePassthrough, RunnableLambda
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.documents import Document
 
 from config import (
     DOCS_FOLDER, ALLOWED_EXTENSIONS, ROLE_HIERARCHY,
-    VECTOR_STORE_PATH, CHUNK_SIZE, CHUNK_OVERLAP,
+    PERSIST_DIRECTORY,
+    CHUNK_SIZE, CHUNK_OVERLAP,
     EMBEDDING_MODEL, LLM_MODEL
 )
-
 
 # --- Document Loading & Role Tagging ---
 
 def get_role_from_filename(filename):
-    """Extracts the minimum required role from the filename suffix."""
+    """
+    Extracts the minimum required role ('public', 'staff', 'hr', 'manager')
+    from the filename suffix (e.g., '_public', '_staff').
+    Defaults to 'staff' if no valid, recognized tag is found.
+    """
     base = os.path.splitext(filename)[0]
     parts = base.split('_')
     if len(parts) > 1:
+        # Check the last part as potential tag
         role_tag = parts[-1].lower()
-        if role_tag in ROLE_HIERARCHY:
+        # Verify if the tag is one of the defined roles or 'public'
+        if role_tag in ROLE_HIERARCHY: # Checks against keys: 'customer', 'public', 'staff', 'hr', 'manager'
+             # Return the valid tag found (e.g., 'public', 'staff')
             return role_tag
-    return "staff"  # Default to lowest access if no valid tag
+    # If no recognized tag found after '_', default to 'staff' access level.
+    # This means untagged files require at least staff level access.
+    print(f"Info: No specific role tag (e.g., _public, _staff) found for '{filename}'. Defaulting to 'staff' access level.")
+    return 'staff'
 
 
 def load_documents():
-    """Loads documents from DOCS_FOLDER, extracts role from filename, and adds metadata."""
+    """
+    Loads documents from DOCS_FOLDER, extracts role from filename suffix,
+    and adds 'role' (name) and 'role_level' (numeric) metadata.
+    """
     print(f"Loading documents from: {DOCS_FOLDER}")
     docs = []
     for ext in ALLOWED_EXTENSIONS:
         for filepath in glob.glob(os.path.join(DOCS_FOLDER, f"*{ext}")):
             filename = os.path.basename(filepath)
+            # Determine the role string ('public', 'staff', 'hr', 'manager') using the updated function
             role = get_role_from_filename(filename)
-            print(f" - Loading {filename} (Role: {role})")
+            # Get the corresponding numeric level from the hierarchy, default high if role invalid
+            role_level = ROLE_HIERARCHY.get(role, ROLE_HIERARCHY['manager'])
+            print(f" - Loading {filename} (Role Tag: {role}, Assigned Level: {role_level})")
             try:
                 if ext == ".pdf":
                     loader = PyPDFLoader(filepath)
                 elif ext == ".txt":
                     loader = TextLoader(filepath)
                 else:
-                    continue  # Should not happen due to glob pattern
+                    continue # Should not happen due to glob pattern
 
                 loaded_docs = loader.load()
-                # Add metadata (role and source) to each document page/chunk precursor
+                # Add metadata to each document page/chunk precursor
                 for doc in loaded_docs:
-                    doc.metadata["role"] = role
-                    doc.metadata["source"] = filename  # Keep track of original file
+                    doc.metadata["role"] = role # Store role name/tag used
+                    doc.metadata["source"] = filename
+                    doc.metadata["role_level"] = role_level # Store numeric level for filtering
                 docs.extend(loaded_docs)
             except Exception as e:
                 print(f"   Error loading {filename}: {e}")
     print(f"Total documents loaded: {len(docs)}")
     return docs
 
-
-# --- Text Splitting ---
+# --- Text Splitting --- (No changes)
 text_splitter = RecursiveCharacterTextSplitter(
     chunk_size=CHUNK_SIZE,
     chunk_overlap=CHUNK_OVERLAP
 )
 
-# --- Embeddings ---
+# --- Embeddings --- (No changes)
 print(f"Loading embedding model: {EMBEDDING_MODEL}")
 embeddings = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
 print("Embedding model loaded.")
 
-# --- Vector Store ---
+# --- Vector Store (ChromaDB) ---
 vector_store = None
 
-
 def create_or_load_vector_store():
-    """Creates the vector store if it doesn't exist, otherwise loads it."""
+    """Creates the Chroma vector store if it doesn't exist, otherwise loads it."""
     global vector_store
-    if os.path.exists(VECTOR_STORE_PATH):
-        print(f"Loading existing vector store from: {VECTOR_STORE_PATH}")
-        vector_store = FAISS.load_local(VECTOR_STORE_PATH, embeddings,
-                                        allow_dangerous_deserialization=True)  # Be careful with this in production
-        print("Vector store loaded.")
+    if os.path.exists(PERSIST_DIRECTORY):
+        print(f"Loading existing Chroma vector store from: {PERSIST_DIRECTORY}")
+        vector_store = Chroma(
+            persist_directory=PERSIST_DIRECTORY,
+            embedding_function=embeddings
+        )
+        print("Chroma vector store loaded.")
     else:
-        print("Creating new vector store...")
+        print("Creating new Chroma vector store...")
+        # load_documents now adds 'role' and 'role_level' based on filename tag
         documents = load_documents()
         if not documents:
             print("No documents found to create vector store. Aborting.")
             return None
 
         chunks = text_splitter.split_documents(documents)
-        # Ensure metadata is preserved during splitting
-        # RecursiveCharacterTextSplitter usually does this automatically
         print(f"Split documents into {len(chunks)} chunks.")
 
-        # Example check for metadata persistence
-        if chunks and 'role' not in chunks[0].metadata:
-            print("Warning: Metadata might not be preserved correctly during splitting!")
+        # Verify metadata propagation (optional check)
+        if chunks and 'role_level' not in chunks[0].metadata:
+             print("Warning: Metadata ('role_level') might not be propagating correctly during splitting!")
 
-        print("Creating FAISS index...")
-        vector_store = FAISS.from_documents(chunks, embeddings)
-        print("FAISS index created.")
-        print(f"Saving vector store to: {VECTOR_STORE_PATH}")
-        vector_store.save_local(VECTOR_STORE_PATH)
-        print("Vector store saved.")
+        print("Creating Chroma database and adding documents...")
+        vector_store = Chroma.from_documents(
+            documents=chunks,
+            embedding=embeddings,
+            persist_directory=PERSIST_DIRECTORY # Tell Chroma where to save/persist
+        )
+        print(f"Chroma database created and persisted to: {PERSIST_DIRECTORY}")
     return vector_store
 
-
-# Ensure vector store is loaded/created when module is imported
+# Initialize vector store on module import
 vector_store = create_or_load_vector_store()
 
 # --- LLM and RAG Chain ---
-
 if vector_store:
     print(f"Initializing LLM: {LLM_MODEL}")
     llm = Ollama(model=LLM_MODEL)
     print("LLM initialized.")
 
-    # Define the RAG prompt template
-    # Explicitly telling the LLM to use *only* the context is crucial for reducing hallucinations.
+    # RAG prompt template instructing the LLM on behavior
     template = """
-        You are an internal knowledge assistant for African Institute for Artificial Intelligence (AI4AI).
+    You are an internal knowledge assistant for African Institute for Artificial Intelligence (AI4AI).
         Answer the question(s) based ONLY on the following context provided. Do not output your reasoning or expose context information
         If the context is empty, states 'No relevant documents were found or accessible for your role. Kindly open a ticket', or does not contain the answer, state clearly: 'Based on the documents I can access, I cannot answer that question. Kindly open a ticket'
         Do not make up information or use external knowledge.
         Be concise and helpful.
 
-        Context:
-        {context}
+    Context:
+    {context}
 
-        Question:
-        {question}
+    Question:
+    {question}
 
-        Answer:
-        """
+    Answer:
+    """
     prompt = ChatPromptTemplate.from_template(template)
-
-    # Output parser
     output_parser = StrOutputParser()
-
-
-    def filter_documents_by_role(docs, user_role):
-        """Filters retrieved documents based on user's role hierarchy."""
-        user_level = ROLE_HIERARCHY.get(user_role, 0)
-        allowed_docs = []
-        print(f"Filtering {len(docs)} retrieved docs for user role '{user_role}' (level {user_level})...")
-        for doc in docs:
-            doc_role = doc.metadata.get("role", "staff")  # Default to lowest if missing
-            doc_level = ROLE_HIERARCHY.get(doc_role, 0)
-            if user_level >= doc_level:
-                print(
-                    f"  - Allowing doc from '{doc.metadata.get('source', 'N/A')}' (role: {doc_role}, level: {doc_level})")
-                allowed_docs.append(doc)
-            else:
-                print(
-                    f"  - Denying doc from '{doc.metadata.get('source', 'N/A')}' (role: {doc_role}, level: {doc_level}) - Requires higher role.")
-        print(f"Allowed {len(allowed_docs)} docs after filtering.")
-        return allowed_docs
-
 
     def format_docs(docs):
         """Helper function to format documents for the prompt context."""
         if not docs:
-            return "No relevant documents found or accessible."
-        # Include source and role info in context for clarity (optional but helpful for debugging)
-        # return "\n\n".join(f"Source: {doc.metadata.get('source', 'N/A')}, Role: {doc.metadata.get('role', 'N/A')}\nContent: {doc.page_content}" for doc in docs)
-        # Simpler version for final prompt:
+            # This message is crucial for the ticket trigger logic
+            return "No relevant documents were found or accessible for your role."
         return "\n\n".join(doc.page_content for doc in docs)
 
 
-    # Define the RAG chain
     def get_rag_chain(user_role):
-        """Creates and returns the RAG chain, incorporating role-based filtering."""
+        """Creates the RAG chain with Chroma pre-filtering based on the user's role."""
         if not vector_store:
-            print("Error: Vector store not available.")
-            # Return a dummy chain or raise an error
-            return RunnablePassthrough()  # Placeholder that does nothing useful
+            print("Error: Vector store is not available.")
+            def explain_issue(_): return "Knowledge base is currently unavailable. Please try again later."
+            return RunnableLambda(explain_issue)
 
-        retriever = vector_store.as_retriever(search_kwargs={"k": 5})  # Retrieve top 5 chunks initially
+        # Get numeric level for the user's role (customer=0, staff=1, etc.)
+        user_level = ROLE_HIERARCHY.get(user_role, -1) # Default to -1 (no access) if role is invalid
 
-        # Chain definition
+        if user_level == -1:
+             print(f"Error: Invalid user role '{user_role}' provided.")
+             def explain_issue(_): return f"Error: Invalid role '{user_role}'. Access denied."
+             return RunnableLambda(explain_issue)
+
+        # Configure the retriever with Chroma's metadata filtering
+        retriever = vector_store.as_retriever(
+            search_type="similarity",
+            search_kwargs={
+                "k": 5, # Retrieve top 5 relevant chunks matching the filter
+                "filter": {
+                    # Only retrieve documents where 'role_level' <= user's level
+                    "role_level": {"$lte": user_level}
+                }
+            }
+        )
+        print(f"Configured Chroma retriever for role '{user_role}' (level {user_level}) with filter: role_level <= {user_level}")
+
+        def retrieve_and_format_docs(input_data):
+            """Retrieves docs using the role-filtered retriever and formats them."""
+            question = str(input_data) # Input is the question string
+            if not question:
+                return "No question provided."
+            docs = retriever.invoke(question)
+            print(f"Retrieved {len(docs)} docs after filtering for role '{user_role}' matching query '{question[:50]}...'")
+            return format_docs(docs)
+
+        # Define the RAG chain
         rag_chain = (
-                {"context": (lambda x: x['question']) | retriever | (
-                    lambda docs: filter_documents_by_role(docs, user_role)) | format_docs,
-                 "question": RunnablePassthrough()}
-                | prompt
-                | llm
-                | output_parser
+            # The input question goes to both context retrieval and the final prompt
+            {"context": RunnableLambda(retrieve_and_format_docs), "question": RunnablePassthrough()}
+            | prompt
+            | llm
+            | output_parser
         )
         return rag_chain
 
 else:
+    # Handle case where vector store failed to initialize
     print("Cannot initialize RAG chain because vector store failed to load/create.")
-
-
-    # Define a placeholder function or handle this error appropriately in the app
     def get_rag_chain(user_role):
-        raise RuntimeError("RAG system could not be initialized. Check document loading and vector store creation.")
+         def explain_issue(_): return "Error: RAG system could not be initialized. Check logs."
+         return RunnableLambda(explain_issue)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
+# requirements.txt
 langchain
 langchain-community
 langchain-core
 langchain-text-splitters
 streamlit
 sentence-transformers
-faiss-cpu  # Or faiss-gpu if you have CUDA configured
 ollama
-PyPDF2 # Required by PyPDFLoader
+pypdf # For PyPDFLoader
+chromadb # For Chroma vector store
+# Note: faiss-cpu is no longer required

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+langchain
+langchain-community
+langchain-core
+langchain-text-splitters
+streamlit
+sentence-transformers
+faiss-cpu  # Or faiss-gpu if you have CUDA configured
+ollama
+PyPDF2 # Required by PyPDFLoader

--- a/ticket_system.py
+++ b/ticket_system.py
@@ -1,0 +1,37 @@
+import re
+from config import TICKET_KEYWORD_MAP, TICKET_TEAMS
+from database_utils import save_ticket
+
+
+def suggest_ticket_team(question):
+    """Suggests a ticket team based on keywords in the question."""
+    question_lower = question.lower()
+    # Use word boundaries to avoid partial matches (e.g., 'manager' in 'management')
+
+    for team, keywords in TICKET_KEYWORD_MAP.items():
+        for keyword in keywords:
+            # Simple check if keyword exists as a whole word or part of the question
+            # Using regex for slightly better matching (e.g., handles plurals simply sometimes)
+            if re.search(r'\b' + re.escape(keyword) + r'\b', question_lower):  # \b is word boundary
+                print(f"Keyword '{keyword}' matched for team '{team.upper()}'")
+                return team.upper()  # Return the standardized team name
+            # Fallback simple check if regex fails or for broader match
+            elif keyword in question_lower:
+                print(f"Substring '{keyword}' matched for team '{team.upper()}'")
+                return team.upper()
+
+    print("No specific keywords matched, suggesting 'General'.")
+    return "General"  # Default team if no keywords match
+
+
+def create_ticket(user_role, question, chat_history_summary, suggested_team, selected_team):
+    """Creates a ticket entry."""
+    print(f"Creating ticket for team '{selected_team}' (Suggested: '{suggested_team}')")
+    success = save_ticket(
+        user_role=user_role,
+        question=question,
+        chat_history=chat_history_summary,  # Store summary or relevant part
+        suggested_team=suggested_team,
+        selected_team=selected_team
+    )
+    return success

--- a/ticket_system.py
+++ b/ticket_system.py
@@ -1,36 +1,39 @@
+# ticket_system.py
 import re
 from config import TICKET_KEYWORD_MAP, TICKET_TEAMS
 from database_utils import save_ticket
 
-
 def suggest_ticket_team(question):
     """Suggests a ticket team based on keywords in the question."""
     question_lower = question.lower()
-    # Use word boundaries to avoid partial matches (e.g., 'manager' in 'management')
 
-    for team, keywords in TICKET_KEYWORD_MAP.items():
+    # Iterate through the configured teams and their keywords
+    for team_name, keywords in TICKET_KEYWORD_MAP.items():
+        # Standardize team name from config key (e.g., "customer support" -> "Customer Support")
+        display_team_name = " ".join(word.capitalize() for word in team_name.split())
+
         for keyword in keywords:
-            # Simple check if keyword exists as a whole word or part of the question
-            # Using regex for slightly better matching (e.g., handles plurals simply sometimes)
-            if re.search(r'\b' + re.escape(keyword) + r'\b', question_lower):  # \b is word boundary
-                print(f"Keyword '{keyword}' matched for team '{team.upper()}'")
-                return team.upper()  # Return the standardized team name
-            # Fallback simple check if regex fails or for broader match
+            # Use word boundaries for more precise matching
+            if re.search(r'\b' + re.escape(keyword) + r'\b', question_lower):
+                print(f"Keyword '{keyword}' matched for team '{display_team_name}'")
+                return display_team_name
+            # Fallback to simple substring check
             elif keyword in question_lower:
-                print(f"Substring '{keyword}' matched for team '{team.upper()}'")
-                return team.upper()
+                 print(f"Substring '{keyword}' matched for team '{display_team_name}'")
+                 return display_team_name
 
+    # If no specific keywords match across any team
     print("No specific keywords matched, suggesting 'General'.")
-    return "General"  # Default team if no keywords match
-
+    # Ensure 'General' is in the TICKET_TEAMS list from config for consistency
+    return "General" if "General" in TICKET_TEAMS else TICKET_TEAMS[0] # Fallback safely
 
 def create_ticket(user_role, question, chat_history_summary, suggested_team, selected_team):
-    """Creates a ticket entry."""
-    print(f"Creating ticket for team '{selected_team}' (Suggested: '{suggested_team}')")
+    """Creates a ticket entry in the database."""
+    print(f"Creating ticket for team '{selected_team}' (Suggested: '{suggested_team}') submitted by role '{user_role}'")
     success = save_ticket(
         user_role=user_role,
         question=question,
-        chat_history=chat_history_summary,  # Store summary or relevant part
+        chat_history=chat_history_summary, # Store summary or relevant part
         suggested_team=suggested_team,
         selected_team=selected_team
     )


### PR DESCRIPTION
Adds a 'customer' role (level 0 access) to the knowledge assistant PoC, enabling it to serve both internal users and external customers. Customers can only access documents specifically tagged as _public.
This leverages the existing ChromaDB RBAC pre-filtering and includes minor prompt/UI refinements (LLM summarization, <think> tag removal).
Key Changes:
Added customer role and _public tag handling to config.py & rag_processor.py.
Included faq_public.txt sample document.
Added "Customer Support" team and relevant keywords to config.py & ticket_system.py.
Implemented cleanup for <think> tags in LLM responses (app.py).
Refined RAG prompt for better summarization (rag_processor.py).
Testing:
⚠️ IMPORTANT: Delete the existing chroma_db directory to force recreation.
Run streamlit run app.py. Check terminal logs for faq_public.txt loading at level 0.
Test Customer Role: Verify access ONLY to public info and denial for internal info (should offer ticket).
Test Internal Roles (Staff, HR, Manager): Confirm their respective access levels work correctly (including access to public docs) and that RBAC denials occur as expected.
Verify UI: Ensure <think> tags are hidden in responses.
Check Tickets: Confirm ticket offers trigger correctly on access denial/missing info.